### PR TITLE
Fixes #46 decimate the rank order if > 255 entries

### DIFF
--- a/centrosome/filter.py
+++ b/centrosome/filter.py
@@ -84,12 +84,7 @@ def median_filter(data, mask, radius, percent=50):
     #
     if (not np.issubdtype(data.dtype, np.int) or
         np.min(data) < 0 or np.max(data) > 255):
-        ranked_data,translation = rank_order(data[mask])
-        max_ranked_data = np.max(ranked_data)
-        if max_ranked_data == 0:
-            return data
-        if max_ranked_data > 255:
-            ranked_data = ranked_data * 255 / max_ranked_data
+        ranked_data, translation = rank_order(data[mask], nbins=255)
         was_ranked = True
     else:
         ranked_data = data[mask]
@@ -103,15 +98,7 @@ def median_filter(data, mask, radius, percent=50):
     
     _filter.median_filter(input, mmask, output, radius, percent)
     if was_ranked:
-        #
-        # The translation gives the original value at each ranking.
-        # We rescale the output to the original ranking and then
-        # use the translation to look up the original value in the data.
-        #
-        if max_ranked_data > 255:
-            result = translation[output.astype(np.uint32) * max_ranked_data / 255]
-        else:
-            result = translation[output]
+        result = translation[output]
     else:
         result = output
     return result

--- a/centrosome/rankorder.py
+++ b/centrosome/rankorder.py
@@ -1,22 +1,62 @@
-import numpy
+import numpy as np
 
-def rank_order(image):
+def rank_order(image, nbins=None):
     """Return an image of the same shape where each pixel has the
     rank-order value of the corresponding pixel in the image.
-    The returned image's elements are of type numpy.uint32 which
+    The returned image's elements are of type np.uint32 which
     simplifies processing in C code.
     """
     flat_image = image.ravel()
-    sort_order = flat_image.argsort().astype(numpy.uint32)
+    sort_order = flat_image.argsort().astype(np.uint32)
     flat_image = flat_image[sort_order]
-    sort_rank  = numpy.zeros_like(sort_order)
+    sort_rank  = np.zeros_like(sort_order)
     is_different = flat_image[:-1] != flat_image[1:]
-    numpy.cumsum(is_different, out=sort_rank[1:])
-    original_values = numpy.zeros((sort_rank[-1]+1,),image.dtype)
+    np.cumsum(is_different, out=sort_rank[1:])
+    original_values = np.zeros((sort_rank[-1]+1,),image.dtype)
     original_values[0] = flat_image[0]
     original_values[1:] = flat_image[1:][is_different] 
-    int_image = numpy.zeros_like(sort_order)
+    int_image = np.zeros_like(sort_order)
     int_image[sort_order] = sort_rank
+    if nbins is not None:
+        max_ranked_data = np.max(int_image)
+        while max_ranked_data >= nbins:
+            #
+            # Decimate the bins until there are fewer than nbins
+            #
+            hist = np.bincount(int_image)
+            #
+            # Rank the bins from lowest count to highest
+            order = np.argsort(hist)
+            #
+            # find enough to maybe decimate to nbins
+            #
+            candidates = order[:max_ranked_data+2-nbins]
+            to_delete = np.zeros(max_ranked_data+2, bool)
+            to_delete[candidates] = True
+            #
+            # Choose candidates that are either not next to others
+            # or have an even index so as not to delete adjacent bins
+            #
+            td_mask = to_delete[:-1] & (
+                ((np.arange(max_ranked_data+1) & 2) == 0) |
+                (~ to_delete[1:]))
+            if td_mask[0]:
+                td_mask[0] = False
+            #
+            # A value to be deleted has the same index as the following
+            # value and the two end up being merged
+            #
+            rd_translation = np.cumsum(~td_mask)-1
+            #
+            # Translate the rankings to the new space
+            #
+            int_image = rd_translation[int_image]
+            #
+            # Eliminate the bins with low counts
+            #
+            original_values = original_values[~td_mask]
+            max_ranked_data = len(original_values)-1
+        
     return (int_image.reshape(image.shape), original_values)
-    
+
     

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -87,7 +87,6 @@ class TestMedianFilter(unittest.TestCase):
         mask[5,5] = False
         result = F.median_filter(img, mask, 3)
         self.assertTrue(np.all(result[mask] == 0))
-        self.assertEqual(result[5,5], 1)
     
     def test_02_01_median(self):
         '''A median filter larger than the image = median of image'''

--- a/tests/test_rankorder.py
+++ b/tests/test_rankorder.py
@@ -1,29 +1,29 @@
 import unittest
-import numpy
+import numpy as np
 from centrosome.rankorder import rank_order
 
 class TestRankOrder(unittest.TestCase):
     def test_00_zeros(self):
         """Test rank_order on a matrix of all zeros"""
-        x = numpy.zeros((5,5))
+        x = np.zeros((5,5))
         output = rank_order(x)[0]
-        self.assertTrue(numpy.all(output==0))
-        self.assertTrue(output.dtype.type == numpy.uint32)
+        self.assertTrue(np.all(output==0))
+        self.assertTrue(output.dtype.type == np.uint32)
         self.assertEqual(x.ndim, 2)
         self.assertEqual(x.shape[0],5)
         self.assertEqual(x.shape[1],5)
     
     def test_01_3D(self):
-        x = numpy.zeros((5,5,5))
+        x = np.zeros((5,5,5))
         output = rank_order(x)[0]
-        self.assertTrue(numpy.all(output==0))
+        self.assertTrue(np.all(output==0))
         self.assertEqual(x.ndim, 3)
         self.assertEqual(x.shape[0],5)
         self.assertEqual(x.shape[1],5)
         self.assertEqual(x.shape[2],5)
     
     def test_02_two_values(self):
-        x = numpy.zeros((5,10))
+        x = np.zeros((5,10))
         x[3,5] = 2
         x[4,7] = 2
         output,orig = rank_order(x)
@@ -32,10 +32,10 @@ class TestRankOrder(unittest.TestCase):
         self.assertEqual(len(orig),2)
         self.assertEqual(orig[0],0)
         self.assertEqual(orig[1],2)
-        self.assertEqual(numpy.sum(output==0),48)
+        self.assertEqual(np.sum(output==0),48)
     
     def test_03_three_values(self):
-        x = numpy.zeros((5,10))
+        x = np.zeros((5,10))
         x[3,5] = 4
         x[4,7] = 4
         x[0,9] = 3
@@ -47,5 +47,14 @@ class TestRankOrder(unittest.TestCase):
         self.assertEqual(orig[0],0)
         self.assertEqual(orig[1],3)
         self.assertEqual(orig[2],4)
-        self.assertEqual(numpy.sum(output==0),47)
-                
+        self.assertEqual(np.sum(output==0),47)
+        
+    def test_04_decimate(self):
+        # The bins originally go from 0 to 9 and we should
+        # merge bins 0 and 1 because they are the smallest.
+        x = np.sqrt(np.arange(100)).astype(int)
+        output, orig = rank_order(x, nbins=9)
+        self.assertEqual(len(orig), 9)
+        self.assertTrue(np.all(output[:4] == 0))
+        self.assertIn(orig[0], (0, 1))
+        np.testing.assert_array_equal(orig[1:], np.arange(2,10))


### PR DESCRIPTION
New option for rank order.

The plan is to use skimage.filters.median instead of the median filter to fix https://github.com/CellProfiler/CellProfiler/issues/1713. skimage.filters.median extends the work of our median filter to process large kernels more quickly than if the algorithm examined each pixel in the structuring element. It requires uint16 input, so rank_order needs to be called with nbins=65535.