### PR TITLE
Feature/faster zernike

### DIFF
--- a/centrosome/zernike.py
+++ b/centrosome/zernike.py
@@ -112,13 +112,14 @@ def score_zernike(zf, radii, labels, indexes=None):
         indexes = np.arange(1,np.max(labels)+1,dtype=np.int32)
     else:
         indexes = np.array(indexes, dtype=np.int32)
-    radii = np.array(radii)
+    radii = np.asarray(radii, dtype=float)
+    n = radii.size
     k = zf.shape[2]
-    n = np.product(radii.shape)
     score = np.zeros((n,k))
     if n == 0:
         return score
-    areas = radii**2 * np.pi
+    areas = np.square(radii)
+    areas *= np.pi
     for ki in range(k):
         zfk=zf[:,:,ki]
         real_score = scipy.ndimage.sum(zfk.real,labels,indexes)
@@ -126,7 +127,12 @@ def score_zernike(zf, radii, labels, indexes=None):
             
         imag_score = scipy.ndimage.sum(zfk.imag,labels,indexes)
         imag_score = fixup_scipy_ndimage_result(imag_score)
-        one_score = np.sqrt(real_score**2+imag_score**2) / areas
+        # one_score = np.sqrt(real_score**2+imag_score**2) / areas
+        np.square(real_score, out=real_score)
+        np.square(imag_score, out=imag_score)
+        one_score = real_score + imag_score
+        np.sqrt(one_score, out=one_score)
+        one_score /= areas
         score[:,ki] = one_score
     return score
 

--- a/centrosome/zernike.py
+++ b/centrosome/zernike.py
@@ -196,9 +196,12 @@ def get_zernike_indexes(limit=10):
     The Zernikes are stored as complex numbers with the real part
     being (N,M) and the imaginary being (N,-M)
     """
-    zernike_n_m = []
-    for n in range(limit):
-        for m in range(n+1):
-            if (m+n) & 1 == 0:
-                zernike_n_m.append((n,m))
-    return np.array(zernike_n_m)
+    def zernike_indexes_iter(n_max):
+        for n in range(0, n_max):
+            for m in range(n%2, n+1, 2):
+                yield n
+                yield m
+
+    z_ind = np.fromiter(zernike_indexes_iter(limit), np.intc)
+    z_ind = z_ind.reshape( (len(z_ind) // 2, 2) )
+    return z_ind


### PR DESCRIPTION
1. Small improvements to `construct_zernike_lookuptable`
   fixing potential problem manifesting itself when input
   order exceeded 100.

   Avoided using power to compute (-1)**k, using a variable
   that was being negated at each iteration instead.

2. Reworked `construct_zernike_polynomials` to avoid computation
   of `arctan2(x,y)`, radial powers and complex exponentials by using
   the following identity

```
      r**m * np.exp(1j * m * np.arctan2(x, y)) == \
         (y + 1j*x) ** m
```
   and taking advantage of the property of radial Zernike polynomials
   that the lowest order of the radial polynomial of order (n,m) is abs(m).

   This also eliminated the need to compute `np.sqrt(r_square)`.

   Instead of caching `np.exp(1j*m*phi)`, code now caches `z ** m`, where
   `z = y + 1j*x`

   Reworked evaluation of the reduced radial Zernike polynomial
   (with lowest order being 0) using more numerically accurate [Horner scheme](https://en.wikipedia.org/wiki/Horner%27s_method).

3. This resulted in 8X improvement in computation of the Zernike polynomials
   of order 0 through 20 inclusive for a million of random points uniformly
   distributed over a unit disk. Sample output of my local benchmark script:

```
Computing all Zernike polynomials up to order 21
Computer Zernike polynomials values at 1000000 points within unit circle
np.allclose(z_orig, z_improved) = True
Times (t_orig, t_improved) = (35.477564096450806, 4.306720972061157)
```

   which constitutes a factor of 8.2 improvement over the previous code.