### PR TITLE
Bugfix/update to numpy 1.13

### DIFF
--- a/centrosome/cpmorphology.py
+++ b/centrosome/cpmorphology.py
@@ -751,9 +751,9 @@ def convex_hull_ijv(pixel_labels, indexes, fast=True):
         finish_me = ((new_counts > 0) & 
                      ((new_counts <= done_count) | 
                       (new_counts == counts)))
-        indexes_to_finish = np.argwhere(finish_me).astype(np.int32)
+        indexes_to_finish = np.argwhere(finish_me).astype(np.int32).squeeze()
         keep_me = (new_counts > done_count) & (new_counts < counts)
-        indexes_to_keep = np.argwhere(keep_me).astype(np.int32)
+        indexes_to_keep = np.argwhere(keep_me).astype(np.int32).squeeze()
         if len(indexes_to_finish):
             result_counts[finish_me] = new_counts[finish_me]
             #

--- a/centrosome/filter.py
+++ b/centrosome/filter.py
@@ -1869,7 +1869,7 @@ def poisson_equation(image, gradient=1, max_iter=100, convergence=.01, percentil
                                0:(sub_pe.shape[1]*2)].astype(float) / 2
         pe[1:(sub_image.shape[0]*2+1), 1:(sub_image.shape[1]*2+1)] = \
             scind.map_coordinates(sub_pe, coordinates, order=1)
-        pe[~image] = 0
+        pe[:image.shape[0], :image.shape[1]][~image] = 0
     else:
         pe[1:-1,1:-1] = image
     #


### PR DESCRIPTION
Two small changes to makes centrosome's tests pass with NumPy 1.13, both failures were due to the change that NumPy now requires array and the mask to have identical shapes, whereas earlier it would give
`VisibleDeprecationWarning`:

```
>>> import numpy as np
>>> np.__version__
'1.12.1'
>>> x = np.array([[False, True, True, False], [True, False, True, True], [True, False, True, True]], dtype=np.bool)
>>> y = np.arange(1, 1 + (x.shape[0]+2)*(x.shape[1]+1)).reshape((x.shape[0]+2, x.shape[1]+1))
>>> y[~x]
__main__:1: VisibleDeprecationWarning: boolean index did not match indexed array along dimension 0; dimension is 5 but corresponding boolean dimension is 3
array([ 1,  4,  7, 12])
```

Now with NumPy 1.13:

```
>>> import numpy as np
>>> np.__version__
'1.13.0'
>>> x = np.array([[False, True, True, False], [True, False, True, True], [True, False, True, True]], dtype=np.bool)
>>> y = np.arange(1, 1 + (x.shape[0]+2)*(x.shape[1]+1)).reshape((x.shape[0]+2, x.shape[1]+1))
>>> y[~x]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: boolean index did not match indexed array along dimension 0; dimension is 5 but corresponding boolean dimension is 3
```

@mcquin @AnneCarpenter 