### PR TITLE
Don't smooth when smoothing factor is 0.

### DIFF
--- a/centrosome/filter.py
+++ b/centrosome/filter.py
@@ -690,11 +690,11 @@ def enhance_dark_holes(image, min_radius, max_radius, mask=None):
             smoothed_image = np.maximum(smoothed_image,output_image)
         previous_reconstructed_image = reconstructed_image
     return smoothed_image
-    
-    
+
+
 def granulometry_filter(image, min_radius, max_radius, mask=None):
     '''Enhances bright structures within a min and max radius using a rolling ball filter
-    
+
     image - grayscale 2-d image
     radii - a vector of radii: we enhance holes at each given radius
     '''
@@ -712,15 +712,15 @@ def granulometry_filter(image, min_radius, max_radius, mask=None):
     selected_granules_image = np.zeros(image.shape)
     #
     # Select granules by successive morphological openings
-    #    
+    #
     for i in range(max_radius+1):
         eroded_image = grey_erosion(eroded_image, mask=mask, footprint = se)
         opened_image = grey_dilation(eroded_image, inverted_image, footprint = se)
-        output_image = previous_opened_image - opened_image 
+        output_image = previous_opened_image - opened_image
         if i >= min_radius:
             selected_granules_image = np.maximum(selected_granules_image, output_image)
-        previous_opened_image = opened_image 
-    return selected_granules_image 
+        previous_opened_image = opened_image
+    return selected_granules_image
 
 def circular_average_filter(image, radius, mask=None):
     '''Blur an image using a circular averaging filter (pillbox)
@@ -1186,7 +1186,7 @@ def line_integration(image, angle, decay, sigma):
     #
     # Smooth in only the i direction
     #
-    smoothed = scind.gaussian_filter1d(rotated, sigma)
+    smoothed = scind.gaussian_filter1d(rotated, sigma) if sigma > 0 else rotated
     #
     # We want img_out[:,j+1] to be img_out[:,j] * decay + img[j+1]
     # Could be done by convolution with a ramp, maybe in FFT domain,


### PR DESCRIPTION
Resolves #79

In scipy 1.0.0, `scipy.ndimage.gaussian_filter1d(X, sigma=0)` always fails with a ZeroDivisionError. Avoid this case by not applying smoothing when the `sigma` parameter (standard deviation for Gaussian kernel) is `0`.

From a previous version of scipy (0.19):

```python
import numpy
import scipy.ndimage

data = numpy.random.rand(100, 100)
sigma = 0

smoothed = scipy.ndimage.gaussian_filter1d(data, sigma)

numpy.all(data == smoothed)
# True
```