### PR TITLE
Fix minor numerical error in Otsu variance computation

### DIFF
--- a/centrosome/otsu.py
+++ b/centrosome/otsu.py
@@ -247,6 +247,6 @@ def running_variance(x):
     x_minus_m = x[1:]-m[1:]
     # s for i=1...
     s = (x_minus_mprev*x_minus_m).cumsum()
-    var = s / np.arange(2,n+1)
+    var = s / np.arange(1,n)
     # Prepend Inf so we have a variance for x[0]
     return np.hstack(([0],var))


### PR DESCRIPTION
Hi all,

The denominator of the running variance function appears to be shifted by 1, creating a biased variance estimator. I assume this is unintended because it's not consistent with the reference given in the code comment. Here is my reasoning, in case I'm mistaken...

From the [reference](https://www.johndcook.com/blog/standard_deviation/), the k-th variance element is S_k/(k-1) for k = 2, ..., n with S_1 = 0.

```
                Element           1    2    3    4    ...  n

reference       denominator            1    2    3    ...  n-1

centrosome      input vector      x[0] x[1] x[2] x[3] ...  x[n-1]
                s                      s[0] s[1] s[2] ...  s[n-2]
                denominator            ?    ?    ?    ...  ?
                function return   [0]  [var ...  ...  ...  ...]
```
`function return` is the variance vector, which means the two `denominator` vectors should match, suggesting centrosome should use`denominator = [1, 2, ..., n-1]` to produce `var` (instead of `[2, 3, ..., n]`).