### PR TITLE
Travis CI: Add Python 3.6 in allow_failures mode and flake8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,22 @@ install:
     - pip install --upgrade wheel
     - pip install --upgrade cython
     - pip install --upgrade numpy
+    - pip install flake8
     - pip install --editable .
 language: python
 notifications:
     email: false
-python:
-    - 2.7
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.6  
+  allow_failures:
+    - python: 3.6
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
     - python setup.py test
 sudo: false


### PR DESCRIPTION
Closing in favor of #88