### PR TITLE
Remove numpy_histogram

### DIFF
--- a/centrosome/threshold.py
+++ b/centrosome/threshold.py
@@ -758,8 +758,8 @@ def sum_of_entropies(image, mask, binary_image):
     log_bg = np.log2(bg)
     #
     # Make these into histograms
-    hfg = numpy_histogram(log_fg, 256, range=(lower,upper))[0]
-    hbg = numpy_histogram(log_bg, 256, range=(lower,upper))[0]
+    hfg = np.histogram(log_fg, 256, range=(lower,upper), normed=False, weights=None)[0]
+    hbg = np.histogram(log_bg, 256, range=(lower,upper), normed=False, weights=None)[0]
     #hfg = scipy.ndimage.histogram(log_fg,lower,upper,256)
     #hbg = scipy.ndimage.histogram(log_bg,lower,upper,256)
     #
@@ -810,11 +810,3 @@ def inverse_log_transform(image, d):
     d - object returned by log_transform
     '''
     return np.exp(unstretch(image, d["log_min"], d["log_max"]))
-
-def numpy_histogram(a, bins=10, range=None, normed=False, weights=None):
-    '''A version of numpy.histogram that accounts for numpy's version'''
-    args = inspect.getargs(np.histogram.__code__)[0]
-    if args[-1] == "new":
-        return np.histogram(a, bins, range, normed, weights, new=True)
-    return np.histogram(a, bins, range, normed, weights)
-    


### PR DESCRIPTION
This function appears to be redundant. Replaced numpy_histogram calls with straight np.histogram calls. I don't think it's used anywhere else. Seems to fix thresholding functions on my clone of CellProfiler.