### PR TITLE
Drop comma that causes install to fail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ for pyxfile in glob.glob(os.path.join("centrosome", "*.pyx")):
         setuptools.Extension(
             name="centrosome.{}".format(name),
             sources=["centrosome/{}.{}".format(name, __suffix)],
-            **__extkwargs,
+            **__extkwargs
         )
     ]
 


### PR DESCRIPTION
This PR simply drops a comma in setup.py that was causing an installation issue on ubuntu 18.04 with both `pip install centrosome` and `python setup.py install`.

`pip 20.0.2 from /usr/local/lib/python2.7/dist-packages/pip (python 2.7)`
`Python 2.7.17`

Here is the error that is fixed:

```
Collecting centrosome
  Using cached centrosome-1.1.7.tar.gz (543 kB)
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-muJE3W/centrosome/setup.py'"'"'; __file__='"'"'/tmp/pip-install-muJE3W/centrosome/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-muJE3W/centrosome/pip-egg-info
         cwd: /tmp/pip-install-muJE3W/centrosome/
    Complete output (6 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-muJE3W/centrosome/setup.py", line 84
        **__extkwargs,
                     ^
    SyntaxError: invalid syntax
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.```