### PR TITLE
remove comma

### DIFF
--- a/centrosome/threshold.py
+++ b/centrosome/threshold.py
@@ -79,7 +79,7 @@ def get_threshold(
     threshold_range_max=None,
     threshold_correction_factor=1.0,
     adaptive_window_size=10,
-    **kwargs,
+    **kwargs
 ):
     """Compute a threshold for an image
     

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ for pyxfile in glob.glob(os.path.join("centrosome", "*.pyx")):
         setuptools.Extension(
             name="centrosome.{}".format(name),
             sources=["centrosome/{}.{}".format(name, __suffix)],
-            **__extkwargs,
+            **__extkwargs
         )
     ]
 


### PR DESCRIPTION
Problem noticed when installing CP 3.1.9 in a conda environment
running 
``git+https://github.com/CellProfiler/CellProfiler.git@v3.1.9`` 
The command above will try to install ``centrosome 1.1.7``, leading to 
```
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-KNnt79/setup.py", line 84
        **__extkwargs,
                     ^
    SyntaxError: invalid syntax
```
this change fixes the issue.
