### PR TITLE
Fix Numpy deprecation warning

### DIFF
--- a/centrosome/cpmorphology.py
+++ b/centrosome/cpmorphology.py
@@ -3240,12 +3240,12 @@ def table_lookup(image, table, border_value, iterations=None):
     center_is_zero = np.array([(x & 2 ** 4) == 0 for x in range(2 ** 9)])
     use_index_trick = False
     if not np.any(table[center_is_zero]) and (
-        np.issubdtype(image.dtype, np.bool) or np.issubdtype(image.dtype, np.integer)
+        np.issubdtype(image.dtype, np.bool_) or np.issubdtype(image.dtype, np.integer)
     ):
         # Use the index trick
         use_index_trick = True
         invert = False
-    elif np.all(table[~center_is_zero]) and np.issubdtype(image.dtype, np.bool):
+    elif np.all(table[~center_is_zero]) and np.issubdtype(image.dtype, np.bool_):
         # All ones stay ones, invert the table and the image and do the trick
         use_index_trick = True
         invert = True


### PR DESCRIPTION
```
FutureWarning: Conversion of the second argument of issubdtype from `bool` to `np.generic` is deprecated. In future, it will be treated as `np.bool_ == np.dtype(bool).type`.
```

It looks like np.bool was actually bugged for a long time and was evaluated as a generic type rather than a boolean. np.bool_ was added as a "proper" boolean type descriptor. They added a deprecation warning to alert people to this. I've switched to bool_, but we might want to double-check that all functionality still works properly.

```
>>> np.issubdtype(bool, np.bool)
True
>>> np.issubdtype(bool, np.bool_)
True
>>> np.issubdtype(int, np.bool)
True
>>> np.issubdtype(int, np.bool_)
False
```