### PR TITLE
Fix sorting of cell objects in Python 3

### DIFF
--- a/centrosome/neighmovetrack.py
+++ b/centrosome/neighmovetrack.py
@@ -308,7 +308,7 @@ class NeighbourMovementTracking(object):
         """
         all_cells = [c for c in all_cells if c != cell]
 
-        sorted_cells = sorted([(cell.distance(c), c) for c in all_cells])
+        sorted_cells = sorted([(cell.distance(c), c) for c in all_cells], key=lambda sc: sc[0])
 
         return [sc[1] for sc in sorted_cells[:k] if sc[0] <= max_dist]
 


### PR DESCRIPTION
It seems that in Python 3 `sorted` really doesn't like being asked to sort tuples which contain objects. Explicitly giving the key seems to fix this.