### PR TITLE
Address numpy deprecation warnings

### DIFF
--- a/centrosome/filter.py
+++ b/centrosome/filter.py
@@ -97,7 +97,7 @@ def median_filter(data, mask, radius, percent=50):
     #
     # Normalize the ranked data to 0-255
     #
-    if not np.issubdtype(data.dtype, np.int) or np.min(data) < 0 or np.max(data) > 255:
+    if not np.issubdtype(data.dtype, int) or np.min(data) < 0 or np.max(data) > 255:
         ranked_data, translation = rank_order(data[mask], nbins=255)
         was_ranked = True
     else:

--- a/centrosome/radial_power_spectrum.py
+++ b/centrosome/radial_power_spectrum.py
@@ -18,9 +18,9 @@ def rps(img):
         img = img / np.median(abs(img - img.mean()))  # intensity invariant
     mag = abs(fft2(img - np.mean(img)))
     power = mag ** 2
-    radii = np.floor(np.sqrt(radii2)).astype(np.int) + 1
+    radii = np.floor(np.sqrt(radii2)).astype(int) + 1
     labels = (
-        np.arange(2, np.floor(maxwidth)).astype(np.int).tolist()
+        np.arange(2, np.floor(maxwidth)).astype(int).tolist()
     )  # skip DC component
     if len(labels) > 0:
         magsum = nd_sum(mag, radii, labels)

--- a/centrosome/zernike.py
+++ b/centrosome/zernike.py
@@ -68,18 +68,18 @@ def construct_zernike_polynomials(x, y, zernike_indexes, mask=None, weight=None)
     # z = y + 1j*x
     # each Zernike polynomial is poly(r)*(r**m * np.exp(1j*m*phi)) ==
     #                            poly(r)*(y + 1j*x)**m
-    z = np.empty(x.shape, np.complex)
+    z = np.empty(x.shape, complex)
     np.copyto(z.real, y)
     np.copyto(z.imag, x)
     # preallocate buffers
     s = np.empty_like(x)
-    zf = np.zeros((nzernikes,) + x.shape, np.complex)
+    zf = np.zeros((nzernikes,) + x.shape, complex)
     z_pows = {}
     for idx, (n, m) in enumerate(zernike_indexes):
         s[:] = 0
         if not m in z_pows:
             if m == 0:
-                z_pows[m] = np.complex(1.0)
+                z_pows[m] = complex(1.0)
             else:
                 z_pows[m] = z if m == 1 else (z ** m)
         z_pow = z_pows[m]
@@ -98,7 +98,7 @@ def construct_zernike_polynomials(x, y, zernike_indexes, mask=None, weight=None)
     if mask is None:
         result = zf.transpose(tuple(range(1, 1 + x.ndim)) + (0,))
     else:
-        result = np.zeros(mask.shape + (nzernikes,), np.complex)
+        result = np.zeros(mask.shape + (nzernikes,), complex)
         result[mask] = zf.transpose(tuple(range(1, 1 + x.ndim)) + (0,))
     return result
 


### PR DESCRIPTION
- part of [cellprofiler pr #
  456](https://github.com/CellProfiler/CellProfiler/pull/4576)
- removes numpy deprecation warnings in cellprofiler tests