### PR TITLE
Change matplotlib to >=3.1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setuptools.setup(
     },
     install_requires=[
         "deprecation",
-        "matplotlib==3.1.3",
+        "matplotlib>=3.1.3",
         "numpy>=1.18.2",
         "pillow>=7.1.0",
         "scikit-image>=0.17.2",


### PR DESCRIPTION
matplotlib 3.1.3 was released in Feb 2020 and does not provide wheels for newer python versions, making installation difficult. [`cellprofiler-core` uses `>=3.1.3`](https://github.com/CellProfiler/core/blob/be7ee8f77a0e5320095db0942f335a4e2ea664e6/setup.py#L31) and other users seem to have [no issues with newer versions](https://github.com/CellProfiler/CellProfiler/issues/4432#issuecomment-919716542), so this relaxes the constraint to `>=3.1.3` here.