### PR TITLE
Update heap.pxd

### DIFF
--- a/centrosome/heap.pxd
+++ b/centrosome/heap.pxd
@@ -145,7 +145,7 @@ cdef inline void heappush(Heap *heap,
 
   # restore heap invariant, all parents <= children
   while child>0:
-      parent = (child + 1) / 2 - 1 # __parent(i)
+      parent = (child + 1) // 2 - 1 # __parent(i)
       
       if smaller(child, parent, heap):
           swap(parent, child, heap)


### PR DESCRIPTION
 Solving Cython.Compiler.Errors.CompileError: centrosome/_propagate.pyx
      [end of output]
centrosome/heap.pxd:148:31: Cannot assign type 'double' to 'unsigned int'

Because of Cython version 3.0