### PR TITLE
scikit-image<1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ setuptools.setup(
         "matplotlib>=3.1.3,<4",
         "numpy>=1.18.2,<2",
         "pillow>=7.1.0,<12",
-        "scikit-image>=0.17.2,<=0.24",
+        "scikit-image>=0.17.2,<1",
         "scipy>=1.4.1,!=1.11.0,<2",
     ],
     tests_require=[


### PR DESCRIPTION
Set upper bound for skimage to 1. 
FYI, the only place skimage is used is in https://github.com/CellProfiler/centrosome/blob/01133c4869eaf71cf4676372ef8b172a1b613433/centrosome/watershed.py#L5